### PR TITLE
Set up markers for upstream/commit subrepo default commit message

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -3,6 +3,7 @@ schema_version: 1
 context:
   name: git-subrepo
   version: 0.4.9
+  remote: https://github.com/ingydotnet/git-subrepo
   git_min: 2.23
 
 package:
@@ -10,14 +11,16 @@ package:
   version: ${{ version }}
 
 source:
-  url: https://github.com/ingydotnet/git-subrepo/archive/${{ version }}.tar.gz
+  url: ${{ remote }}/archive/${{ version }}.tar.gz
   sha256: 775987fbf313c9051d56b757672972629cc44a6cfd9c310fb07f2311f001e432
 
 build:
-  number: 1
+  number: 2
   noarch: generic
   script:
     - make install
+    - echo "${{ remote }}" > $PREFIX/libexec/git-core/git-subrepo.d/upstream
+    - echo "$(git ls-remote ${{ remote }} --tags ${{ version }} | sed 's/^\([0-9a-f]\{7\}\).*/\1/')" > $PREFIX/libexec/git-core/git-subrepo.d/commit
     - mkdir -p $PREFIX/etc/bash_completion.d
     - cp share/completion.bash $PREFIX/etc/bash_completion.d/git-subrepo
     - mkdir -p $PREFIX/share/zsh/site-functions
@@ -28,6 +31,7 @@ build:
 requirements:
   build:
     - make
+    - sed
   host:
     - git >=${{ git_min }}
   run:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
This PR improves the basic configuration of the installed version of git-subrepo such as the upstream and commit  keys are properly filled during automated commits.